### PR TITLE
Health endpoint

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -10,3 +10,4 @@ tensorflow
 torch
 types-requests
 uvicorn
+jupytext

--- a/tests/integration/test_fastapi.py
+++ b/tests/integration/test_fastapi.py
@@ -31,6 +31,8 @@ def _wait_to_exist(port):
         except Exception:  # pylint: disable=broad-except
             time.sleep(1.0)
 
+    assert requests.get(f"http://127.0.0.1:{port}/health").json()["status"] == 200
+
 
 @pytest.mark.parametrize(
     "ml_framework, model_cls_name, model_checker",

--- a/unionml/fastapi.py
+++ b/unionml/fastapi.py
@@ -3,6 +3,7 @@
 import os
 from typing import Any, Dict, List, Optional, Union
 
+from http import HTTPStatus
 from fastapi import Body, FastAPI, HTTPException
 from fastapi.responses import HTMLResponse
 from pydantic import BaseModel
@@ -55,3 +56,7 @@ def serving_app(model: Model, app: FastAPI, remote: bool = False, model_version:
         workflow_inputs.update(inputs if inputs else {"features": features})
 
         return model.predict(**workflow_inputs)
+
+    @app.get("/health")
+    async def health():
+        return {"message": HTTPStatus.OK.phrase, "status": HTTPStatus.OK, "data": {}}

--- a/unionml/fastapi.py
+++ b/unionml/fastapi.py
@@ -60,5 +60,5 @@ def serving_app(model: Model, app: FastAPI, remote: bool = False, model_version:
     @app.get("/health")
     async def health():
         if model.artifact is None:
-            raise HTTPException(status_code=500, detail="Model artifact not available.")
+            raise HTTPException(status_code=500, detail="Model artifact not found.")
         return {"message": HTTPStatus.OK.phrase, "status": HTTPStatus.OK}

--- a/unionml/fastapi.py
+++ b/unionml/fastapi.py
@@ -59,4 +59,6 @@ def serving_app(model: Model, app: FastAPI, remote: bool = False, model_version:
 
     @app.get("/health")
     async def health():
+        if model.artifact is None:
+            raise HTTPException(status_code=500, detail="Model artifact not available.")
         return {"message": HTTPStatus.OK.phrase, "status": HTTPStatus.OK}

--- a/unionml/fastapi.py
+++ b/unionml/fastapi.py
@@ -1,9 +1,9 @@
 """Utilities for the FastAPI integration."""
 
 import os
+from http import HTTPStatus
 from typing import Any, Dict, List, Optional, Union
 
-from http import HTTPStatus
 from fastapi import Body, FastAPI, HTTPException
 from fastapi.responses import HTMLResponse
 from pydantic import BaseModel
@@ -59,4 +59,4 @@ def serving_app(model: Model, app: FastAPI, remote: bool = False, model_version:
 
     @app.get("/health")
     async def health():
-        return {"message": HTTPStatus.OK.phrase, "status": HTTPStatus.OK, "data": {}}
+        return {"message": HTTPStatus.OK.phrase, "status": HTTPStatus.OK}


### PR DESCRIPTION
Fixes https://github.com/unionai-oss/unionml/issues/41

A check to verify if the model exists in memory is already implemented in `setup_model` function that gets triggered on startup. The `health` endpoint is just to ensure that the FastAPI server is up and running.