### PR TITLE
decouple parser from feature-loading/transform

### DIFF
--- a/tests/unit/test_dataset.py
+++ b/tests/unit/test_dataset.py
@@ -80,7 +80,7 @@ def test_dataset_get_features_custom(dataset: Dataset):
 
     @dataset.feature_loader
     def feature_loader(serialized_features: str) -> pd.DataFrame:
-        return pd.DataFrame(json.loads(serialized_features))
+        return pd.DataFrame(json.loads(serialized_features))[dataset._features]
 
     @dataset.feature_transformer
     def feature_transformer(raw_features: pd.DataFrame) -> pd.DataFrame:

--- a/tests/unit/test_type_guards.py
+++ b/tests/unit/test_type_guards.py
@@ -298,6 +298,35 @@ def test_guard_predictor(predictor_fn, is_valid):
             type_guards.guard_predictor(predictor_fn, ModelType, DatasetType)
 
 
+# types
+UnionDatasetType = typing.Union[DatasetType, list]
+
+
+# valid evaluators
+def predictor_valid_union(model_obj: ModelType, features: UnionDatasetType) -> float:
+    ...
+
+
+def predictor_valid_inverted_order(model_obj: ModelType, features: typing.Union[list, DatasetType]) -> float:
+    ...
+
+
+@pytest.mark.parametrize(
+    "predictor_fn, is_valid",
+    [
+        [predictor_valid_union, True],
+        [predictor_valid_inverted_order, True],
+        [predictor_wrong_dtype, False],
+    ],
+)
+def test_guard_predictor_with_unions(predictor_fn, is_valid):
+    if is_valid:
+        type_guards.guard_predictor(predictor_fn, ModelType, UnionDatasetType)
+    else:
+        with pytest.raises(TypeError):
+            type_guards.guard_predictor(predictor_fn, ModelType, UnionDatasetType)
+
+
 # valid feature loaders
 def feature_loader_valid(data: typing.List[int]) -> DatasetType:
     ...

--- a/unionml/model.py
+++ b/unionml/model.py
@@ -486,7 +486,6 @@ class Model(TrackedInstance):
             following order:
 
             - :meth:`unionml.dataset.Dataset.feature_loader`
-            - :meth:`unionml.dataset.Dataset.parser`
             - :meth:`unionml.dataset.Dataset.feature_transformer`
         :param reader_kwargs: keyword arguments that correspond to the :meth:`unionml.Dataset.reader` method signature.
         """
@@ -684,7 +683,6 @@ class Model(TrackedInstance):
             following order:
 
             - :meth:`unionml.dataset.Dataset.feature_loader`
-            - :meth:`unionml.dataset.Dataset.parser`
             - :meth:`unionml.dataset.Dataset.feature_transformer`
         :param reader_kwargs: keyword arguments that correspond to the :meth:`unionml.Dataset.reader` method signature.
         """

--- a/unionml/type_guards.py
+++ b/unionml/type_guards.py
@@ -28,7 +28,7 @@ def _is_tuple_or_list_type(type: Type):
 def _check_input_data_type(fn_name: str, actual_type: Type, expected_type: Type):
     if actual_type != expected_type:
         raise TypeError(
-            f"The type of the first argument of the '{fn_name}' function must match the 'reader' output type: "
+            f"The type of the first argument of the '{fn_name}' function must match the expected output type: "
             f"{expected_type}. Found {actual_type}"
         )
 


### PR DESCRIPTION
Signed-off-by: Niels Bantilan <niels.bantilan@gmail.com>

This PR decouples the runtime and type dependency between the feature loader/transformer and parser. Before this PR, the `Dataset.get_features` method invokes `feature_loader -> parser -> feature_transformer`. This was so that the `parser` is re-used to grab features from the raw feature data.

This isn't great because it adds a level of complexity that isn't needed: basically the `predictor` should be able to handle inputs from both `parser` and `feature_loader -> feature_transformer`. This PR does this decoupling so that the end-user only has to think about predicting from:

- `reader -> ... -> parser -> predictor` : when calling `model.predict(**reader_kwargs)`
- `feature_loader -> feature_transformer -> predictor`: when calling `model.predict(features=features)`