### PR TITLE
fix type guard functions

### DIFF
--- a/tests/unit/test_dataset.py
+++ b/tests/unit/test_dataset.py
@@ -75,7 +75,7 @@ def test_dataset_get_features_default(dataset):
 
 def test_dataset_get_features_custom(dataset: Dataset):
     @dataset.reader
-    def reader() -> pd.DataFrame:
+    def reader() -> str:
         ...
 
     @dataset.feature_loader

--- a/tests/unit/test_type_guards.py
+++ b/tests/unit/test_type_guards.py
@@ -328,7 +328,7 @@ def test_guard_predictor_with_unions(predictor_fn, is_valid):
 
 
 # valid feature loaders
-def feature_loader_valid(data: typing.List[int]) -> DatasetType:
+def feature_loader_valid(data: typing.List[float]) -> DatasetType:
     ...
 
 

--- a/unionml/dataset.py
+++ b/unionml/dataset.py
@@ -6,7 +6,7 @@ from enum import Enum
 from functools import partial
 from inspect import Parameter, _empty, signature
 from pathlib import Path
-from typing import Any, Dict, Iterable, List, NamedTuple, Optional, Tuple, Type, TypeVar, Union, cast
+from typing import Any, Dict, List, NamedTuple, Optional, Tuple, Type, TypeVar, Union, cast
 
 try:
     from typing import get_args  # type: ignore
@@ -181,7 +181,12 @@ class Dataset(TrackedInstance):
 
         And it should return the data structure needed for model training.
         """
-        type_guards.guard_feature_loader(fn, self.parser_return_types[self._parser_feature_key])
+        if self._parser == self._default_parser:
+            type_ = self.dataset_datatype["data"]
+        else:
+            type_ = self.parser_return_types[self._parser_feature_key]
+
+        type_guards.guard_feature_loader(fn, type_)
         self._feature_loader = fn
         return fn
 
@@ -194,7 +199,8 @@ class Dataset(TrackedInstance):
         2. When the FastAPI app `/predict/` endpoint is invoked with features passed in as JSON or string encoding.
         3. When the `model.predict` or `model.remote_predict` functions are invoked.
         """
-        type_guards.guard_feature_transformer(fn, self.parser_return_types[self._parser_feature_key])
+        sig = signature(self._feature_loader)
+        type_guards.guard_feature_transformer(fn, sig.return_annotation)
         self._feature_transformer = fn
         return fn
 
@@ -374,8 +380,8 @@ class Dataset(TrackedInstance):
         return ReaderReturnTypeSource.LOADER if self._loader != self._default_loader else ReaderReturnTypeSource.READER
 
     @property
-    def parser_return_types(self) -> Iterable[Type]:
-        """Get an iterable of types produces by the parser."""
+    def parser_return_types(self) -> Tuple[Any, ...]:
+        """Get an iterable of types produced by the parser."""
         sig = signature(self._parser)
         return get_args(sig.return_annotation)
 
@@ -385,12 +391,16 @@ class Dataset(TrackedInstance):
 
         The fallback behavior occurs if the user didn't define a ``feature_transformer`` function.
         """
-        parser_type = get_args(signature(self._parser).return_annotation)[self._parser_feature_key]
 
-        ft_type = signature(self._feature_transformer).return_annotation
+        if self._parser == self._default_parser:
+            parser_type = self.dataset_datatype["data"]
+        else:
+            parser_type = self.parser_return_types[self._parser_feature_key]
+
         if self._feature_transformer == self._default_feature_transformer:
-            # if the feature transformer is not user-defined, use the parser return signature
-            ft_type = get_args(signature(self._parser).return_annotation)[self._parser_feature_key]
+            ft_type = signature(self._feature_loader).return_annotation
+        else:
+            ft_type = signature(self._feature_transformer).return_annotation
 
         if parser_type != ft_type:
             return cast(Type, Union[ft_type, parser_type])
@@ -406,7 +416,8 @@ class Dataset(TrackedInstance):
     ) -> "Dataset":
         dataset = cls(*args, **kwargs)
         dataset._dataset_task = task
-        dataset._dataset_datatype = task.python_interface.outputs
+        (_, dtype), *_ = task.python_interface.outputs.items()
+        dataset._dataset_datatype = {"data": dtype}
         dataset._reader_input_types = [
             Parameter(k, Parameter.KEYWORD_ONLY, annotation=v) for k, v in task.python_interface.inputs.items()
         ]
@@ -461,10 +472,10 @@ class Dataset(TrackedInstance):
 
     def _default_parser(
         self,
-        data: pd.DataFrame,
+        data: D,
         features: Optional[List[str]],
         targets: Optional[List[str]],
-    ) -> Tuple[pd.DataFrame, pd.DataFrame]:
+    ) -> Tuple[D, D]:
         if not isinstance(data, pd.DataFrame):
             return (data,)  # type: ignore
 

--- a/unionml/model.py
+++ b/unionml/model.py
@@ -195,6 +195,9 @@ class Model(TrackedInstance):
             return partial(self.trainer, **train_task_kwargs)
 
         if self.dataset._parser == self.dataset._default_parser:
+            # Use the reader/loader datatype if parser is the default parser, otherwise use parser return type.
+            # Additionally, special-case dataframes so that they are treated as two dataframes: one for features
+            # and another for targets.
             expected_types = (
                 tuple([self.dataset.dataset_datatype["data"]] * 2)
                 if self.dataset.dataset_datatype["data"] is pd.DataFrame
@@ -222,6 +225,9 @@ class Model(TrackedInstance):
         """Register a function for producing metrics for given model object."""
 
         if self.dataset._parser == self.dataset._default_parser:
+            # Use the reader/loader datatype if parser is the default parser, otherwise use parser return type.
+            # Additionally, special-case dataframes so that they are treated as two dataframes: one for features
+            # and another for targets.
             expected_types = (
                 tuple([self.dataset.dataset_datatype["data"]] * 2)
                 if self.dataset.dataset_datatype["data"] is pd.DataFrame

--- a/unionml/model.py
+++ b/unionml/model.py
@@ -9,6 +9,7 @@ from inspect import Parameter, signature
 from typing import IO, Any, Callable, Dict, List, NamedTuple, Optional, Tuple, Type, Union
 
 import joblib
+import pandas as pd
 import sklearn
 from dataclasses_json import dataclass_json
 from fastapi import FastAPI
@@ -193,7 +194,16 @@ class Model(TrackedInstance):
         if fn is None:
             return partial(self.trainer, **train_task_kwargs)
 
-        type_guards.guard_trainer(fn, self.model_type, self._dataset.parser_return_types)
+        if self.dataset._parser == self.dataset._default_parser:
+            expected_types = (
+                tuple([self.dataset.dataset_datatype["data"]] * 2)
+                if self.dataset.dataset_datatype["data"] is pd.DataFrame
+                else (self.dataset.dataset_datatype["data"],)
+            )
+        else:
+            expected_types = self.dataset.parser_return_types
+
+        type_guards.guard_trainer(fn, self.model_type, expected_types)
         self._trainer = fn
         self._train_task_kwargs = train_task_kwargs
         return self._trainer
@@ -210,7 +220,17 @@ class Model(TrackedInstance):
 
     def evaluator(self, fn):
         """Register a function for producing metrics for given model object."""
-        type_guards.guard_evaluator(fn, self.model_type, self._dataset.parser_return_types)
+
+        if self.dataset._parser == self.dataset._default_parser:
+            expected_types = (
+                tuple([self.dataset.dataset_datatype["data"]] * 2)
+                if self.dataset.dataset_datatype["data"] is pd.DataFrame
+                else (self.dataset.dataset_datatype["data"],)
+            )
+        else:
+            expected_types = self.dataset.parser_return_types
+
+        type_guards.guard_evaluator(fn, self.model_type, expected_types)
         self._evaluator = fn
         return self._evaluator
 
@@ -266,11 +286,12 @@ class Model(TrackedInstance):
             dataset_task,
             **{k: wf.inputs[k] for k in dataset_task.python_interface.inputs},
         )
+        (_, dataset_promise), *_ = dataset_node.outputs.items()
         train_node = wf.add_entity(
             train_task,
             **{
                 hyperparam_arg: wf.inputs[hyperparam_arg],
-                **dataset_node.outputs,
+                **{"data": dataset_promise},
                 **{arg: wf.inputs[arg] for arg in trainer_param_types},
                 **{arg: wf.inputs[arg] for arg in ["loader_kwargs", "splitter_kwargs", "parser_kwargs"]},
             },
@@ -295,8 +316,9 @@ class Model(TrackedInstance):
             dataset_task,
             **{k: wf.inputs[k] for k in dataset_task.python_interface.inputs},
         )
+        (_, dataset_promise), *_ = dataset_node.outputs.items()
         predict_node = wf.add_entity(
-            predict_task, **{"model_object": wf.inputs["model_object"], **dataset_node.outputs}
+            predict_task, **{"model_object": wf.inputs["model_object"], **{"data": dataset_promise}}
         )
         for output_name, promise in predict_node.outputs.items():
             wf.add_workflow_output(output_name, promise)

--- a/unionml/type_guards.py
+++ b/unionml/type_guards.py
@@ -127,7 +127,7 @@ def guard_trainer(trainer: Callable, expected_model_type: Type, expected_data_ty
 
     _check_input_data_type("trainer", actual_model_type, expected_model_type)
     _check_input_data_type("trainer", sig.return_annotation, expected_model_type)
-    # _check_data_types_length(actual_data_types, expected_data_types)
+    _check_data_types_length(actual_data_types, expected_data_types)
     for actual_dtype, expected_dtype in zip(actual_data_types, expected_data_types):
         _check_input_data_type("trainer", actual_dtype, expected_dtype)
 


### PR DESCRIPTION
Signed-off-by: Niels Bantilan <niels.bantilan@gmail.com>

This PR modifies the type guard module to support type compatibility between model/dataset functions that use `Union` types.

It also updates the training workflow and dataset._from_flytekit_task so that the data argument key is always "data", not "results".