### PR TITLE
add tests using UnionML tasks in Flyte workflows

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,7 +24,7 @@ repos:
   hooks:
   - id: shellcheck
 - repo: https://github.com/pre-commit/mirrors-mypy
-  rev: v0.942
+  rev: v0.971
   hooks:
     - id: mypy
       entry: mypy unionml tests

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,0 +1,7 @@
+from tests.unit.dataset_fixtures import (  # noqa
+    dataset,
+    dict_dataset_reader,
+    reader_with_json_string_output,
+    simple_reader,
+)
+from tests.unit.model_fixtures import evaluator, mock_data, model, predictor, raw_model, trainer  # noqa

--- a/tests/unit/dataset_fixtures.py
+++ b/tests/unit/dataset_fixtures.py
@@ -1,0 +1,44 @@
+import json
+import typing
+
+import pytest
+
+from unionml import Dataset
+
+N_SAMPLES = 100
+TEST_SIZE = 0.2
+
+
+@pytest.fixture(scope="function")
+def dataset():
+    return Dataset(
+        features=["x"],
+        targets=["y"],
+        test_size=TEST_SIZE,
+        shuffle=True,
+        random_state=123,
+    )
+
+
+@pytest.fixture(scope="function")
+def simple_reader():
+    def _reader(value: float, n_samples: int) -> typing.List[float]:
+        return [value for _ in range(n_samples)]
+
+    return _reader
+
+
+@pytest.fixture(scope="function")
+def dict_dataset_reader():
+    def _reader() -> typing.List[typing.Dict[str, int]]:
+        return [{"x": i, "y": i * 2} for i in range(1, N_SAMPLES + 1)]
+
+    return _reader
+
+
+@pytest.fixture(scope="function")
+def reader_with_json_string_output(dict_dataset_reader):
+    def _reader() -> str:
+        return json.dumps(dict_dataset_reader())
+
+    return _reader

--- a/tests/unit/model_fixtures.py
+++ b/tests/unit/model_fixtures.py
@@ -1,0 +1,90 @@
+import typing
+
+import pandas as pd
+import pytest
+from sklearn.linear_model import LogisticRegression
+from sklearn.metrics import accuracy_score
+
+from unionml import Dataset, Model
+
+
+@pytest.fixture(scope="function")
+def mock_data() -> pd.DataFrame:
+    return pd.DataFrame(
+        {
+            "x": [1, 2, 3, 4] * 25,
+            "x2": [1, 2, 3, 4] * 25,
+            "x3": [1, 2, 3, 4] * 25,
+            "y": [0, 1, 0, 1] * 25,
+        }
+    )
+
+
+@pytest.fixture(scope="function", params=[{"custom_init": True}, {"custom_init": False}])
+def raw_model(request, mock_data) -> Model:
+
+    dataset = Dataset(
+        features=["x"],
+        targets=["y"],
+        test_size=0.2,
+        shuffle=True,
+        random_state=123,
+    )
+
+    @dataset.reader
+    def reader(sample_frac: float, random_state: int) -> pd.DataFrame:
+        return mock_data.sample(frac=sample_frac, random_state=random_state)
+
+    @dataset.loader
+    def loader(raw_data: pd.DataFrame, head: typing.Optional[int] = None) -> pd.DataFrame:
+        if head is not None:
+            return raw_data.head(head)
+        return raw_data
+
+    model = Model(
+        name="test_model",
+        init=None if request.param["custom_init"] else LogisticRegression,
+        hyperparameter_config={"C": float, "max_iter": int},
+        dataset=dataset,
+    )
+
+    if request.param["custom_init"]:
+        # define custom init function
+        @model.init
+        def init_fn(hyperparameters: dict) -> LogisticRegression:
+            return LogisticRegression(**hyperparameters)
+
+    return model
+
+
+@pytest.fixture(scope="function")
+def trainer():
+    def _trainer(model: LogisticRegression, features: pd.DataFrame, target: pd.DataFrame) -> LogisticRegression:
+        return model.fit(features, target.squeeze())
+
+    return _trainer
+
+
+@pytest.fixture(scope="function")
+def predictor():
+    def _predictor(model: LogisticRegression, features: pd.DataFrame) -> typing.List[float]:
+        return [float(x) for x in model.predict(features)]
+
+    return _predictor
+
+
+@pytest.fixture(scope="function")
+def evaluator():
+    def _evaluator(model: LogisticRegression, features: pd.DataFrame, target: pd.DataFrame) -> float:
+        predictions = model.predict(features)
+        return float(accuracy_score(target, predictions))
+
+    return _evaluator
+
+
+@pytest.fixture(scope="function")
+def model(raw_model, trainer, predictor, evaluator):
+    raw_model.trainer(trainer)
+    raw_model.predictor(predictor)
+    raw_model.evaluator(evaluator)
+    return raw_model


### PR DESCRIPTION
Signed-off-by: Niels Bantilan <niels.bantilan@gmail.com>

Fixes #58

This PR:
- moves the fixtures into separate modules
- creates a `conftest.py` file
- adds happy path tests for using UnionML-derived training and predict tasks in regular Flyte workflows