### PR TITLE
use feature transformer more consistently

### DIFF
--- a/unionml/dataset.py
+++ b/unionml/dataset.py
@@ -323,11 +323,17 @@ class Dataset(TrackedInstance):
         splits = self._splitter(data, **splitter_kwargs)
 
         if len(splits) == 1:
-            return {"train": self._parser(splits[0], **parser_kwargs)}
+            train_data = [*self._parser(splits[0], **parser_kwargs)]
+            train_data[self._parser_feature_key] = self._feature_transformer(train_data[self._parser_feature_key])
+            return {"train": train_data}
 
         train_split, test_split = splits
-        train_data = self._parser(train_split, **parser_kwargs)
-        test_data = self._parser(test_split, **parser_kwargs)
+        train_data = [*self._parser(train_split, **parser_kwargs)]
+        test_data = [*self._parser(test_split, **parser_kwargs)]
+
+        train_data[self._parser_feature_key] = self._feature_transformer(train_data[self._parser_feature_key])
+        test_data[self._parser_feature_key] = self._feature_transformer(test_data[self._parser_feature_key])
+
         return {
             "train": train_data,
             "test": test_data,

--- a/unionml/model.py
+++ b/unionml/model.py
@@ -466,8 +466,8 @@ class Model(TrackedInstance):
             **self._predict_task_kwargs,
         )
         def predict_task(model_object, **kwargs):
-            parsed_data = self._dataset._parser(kwargs[data_arg_name], **self._dataset.parser_kwargs)
-            features = parsed_data[self._dataset._parser_feature_key]
+            parsed_data = self.dataset._parser(kwargs[data_arg_name], **self._dataset.parser_kwargs)
+            features = self.dataset._feature_transformer(parsed_data[self._dataset._parser_feature_key])
             return self._predictor(model_object, features)
 
         self._predict_task = predict_task


### PR DESCRIPTION
Signed-off-by: Niels Bantilan <niels.bantilan@gmail.com>

This PR updates the `Dataset.get_data` method (used in `train_workflow` and `predict_workflow`) to use the `Dataset.feature_transformer` function. This makes the `feature_transformer` reused in both training and prediction use cases.