### PR TITLE
implement callback functions

### DIFF
--- a/tests/unit/test_type_guards.py
+++ b/tests/unit/test_type_guards.py
@@ -258,7 +258,7 @@ def test_guard_evaluator(evaluator_fn, is_valid):
             type_guards.guard_evaluator(evaluator_fn, ModelType, [DatasetType, DatasetType])
 
 
-# valid evaluators
+# valid predictors
 def predictor_valid(model_obj: ModelType, features: DatasetType) -> float:
     ...
 
@@ -296,6 +296,63 @@ def test_guard_predictor(predictor_fn, is_valid):
     else:
         with pytest.raises(TypeError):
             type_guards.guard_predictor(predictor_fn, ModelType, DatasetType)
+
+
+# valid callbacks, assuming use of predictor_valid signature above
+def callback_valid(model_obj: ModelType, features: DatasetType, prediction: float) -> None:
+    ...
+
+
+# invalid callbacks, same assumptions as above
+def callback_wrong_model_type(model_obj: AnotherModelType, features: DatasetType, prediction: float) -> None:
+    ...
+
+
+def callback_wrong_prediction_dtype(model_obj: ModelType, features: DatasetType, prediction: str) -> None:
+    ...
+
+
+def callback_wrong_features_dtype(model_obj: ModelType, features: AnotherDatasetType, prediction: float) -> None:
+    ...
+
+
+def callback_wrong_missing_data(model_obj: ModelType, prediction: float) -> None:
+    ...
+
+
+def callback_wrong_missing_prediction(model_obj: ModelType, features: DatasetType) -> None:
+    ...
+
+
+def callback_wrong_dtype_nargs(
+    model_obj: ModelType, features: DatasetType, prediction: float, prediction2: float
+) -> None:
+    ...
+
+
+def callback_wrong_return_annotation(model_obj: ModelType, features: DatasetType, prediction: float) -> bool:
+    ...
+
+
+@pytest.mark.parametrize(
+    "callback_fn, is_valid",
+    [
+        [callback_valid, True],
+        [callback_wrong_model_type, False],
+        [callback_wrong_prediction_dtype, False],
+        [callback_wrong_features_dtype, False],
+        [callback_wrong_missing_data, False],
+        [callback_wrong_missing_prediction, False],
+        [callback_wrong_dtype_nargs, False],
+        [callback_wrong_return_annotation, False],
+    ],
+)
+def test_guard_callback(callback_fn, is_valid):
+    if is_valid:
+        type_guards.guard_callback(callback_fn, predictor_valid, ModelType, DatasetType)
+    else:
+        with pytest.raises(TypeError):
+            type_guards.guard_callback(callback_fn, predictor_valid, ModelType, DatasetType)
 
 
 # types

--- a/tests/unit/test_type_guards.py
+++ b/tests/unit/test_type_guards.py
@@ -347,12 +347,12 @@ def callback_wrong_return_annotation(model_obj: ModelType, features: DatasetType
         [callback_wrong_return_annotation, False],
     ],
 )
-def test_guard_callback(callback_fn, is_valid):
+def test_guard_prediction_callback(callback_fn, is_valid):
     if is_valid:
-        type_guards.guard_callback(callback_fn, predictor_valid, ModelType, DatasetType)
+        type_guards.guard_prediction_callback(callback_fn, predictor_valid, ModelType, DatasetType)
     else:
         with pytest.raises(TypeError):
-            type_guards.guard_callback(callback_fn, predictor_valid, ModelType, DatasetType)
+            type_guards.guard_prediction_callback(callback_fn, predictor_valid, ModelType, DatasetType)
 
 
 # types

--- a/unionml/model.py
+++ b/unionml/model.py
@@ -397,7 +397,7 @@ class Model(TrackedInstance):
             wf.add_workflow_output(output_name, promise)
 
         if self.callbacks:
-            self.add_workflow_callbacks(False, wf, predict_node.outputs)
+            self.add_workflow_callbacks(wf, predict_node.outputs, has_features=False)
 
         return wf
 
@@ -416,7 +416,7 @@ class Model(TrackedInstance):
             wf.add_workflow_output(output_name, promise)
 
         if self.callbacks:
-            self.add_workflow_callbacks(True, wf, predict_node.outputs)
+            self.add_workflow_callbacks(wf, predict_node.outputs, has_features=True)
 
         return wf
 

--- a/unionml/model.py
+++ b/unionml/model.py
@@ -620,18 +620,13 @@ class Model(TrackedInstance):
                 "predictions."
             )
 
-        wf: Workflow
         if features is None:
-            wf = self.predict_workflow()(model_object=self.artifact.model_object, **reader_kwargs)
+            return self.predict_workflow()(model_object=self.artifact.model_object, **reader_kwargs)
         else:
-            wf = self.predict_from_features_workflow()(
+            return self.predict_from_features_workflow()(
                 model_object=self.artifact.model_object,
                 features=self._dataset.get_features(features),
             )
-
-        # TODO(review,zevisert): Should local predict run callbacks too?
-
-        return wf
 
     def save(self, file: Union[str, os.PathLike, IO], *args, **kwargs):
         """Save the model object to disk."""

--- a/unionml/model.py
+++ b/unionml/model.py
@@ -270,7 +270,7 @@ class Model(TrackedInstance):
                 if not callable(cb):
                     raise ValueError("Callback must be a callable function.")
 
-                type_guards.guard_callback(
+                type_guards.guard_prediction_callback(
                     predictor=fn,
                     callback=cb,
                     expected_model_type=self.model_type,

--- a/unionml/task_resolver.py
+++ b/unionml/task_resolver.py
@@ -34,7 +34,7 @@ class TaskResolver(TrackedInstance, TaskResolverMixin):
         task_method = getattr(_unionml_obj, task_name)
         if task_name.startswith("callback"):
             model: Model = _unionml_obj
-            return task_method(model.__callbacks[task_variant])
+            return task_method(model.callbacks[task_variant])
 
         return task_method()
 

--- a/unionml/task_resolver.py
+++ b/unionml/task_resolver.py
@@ -1,10 +1,17 @@
 import importlib
-from typing import List
+from typing import TYPE_CHECKING, List
 
 from flytekit.core.base_task import TaskResolverMixin
 from flytekit.core.context_manager import SerializationSettings
 from flytekit.core.python_auto_container import PythonAutoContainerTask
 from flytekit.core.tracker import TrackedInstance
+
+if TYPE_CHECKING:
+    from unionml.model import Model
+else:
+
+    class Model:
+        pass
 
 
 class TaskResolver(TrackedInstance, TaskResolverMixin):
@@ -14,10 +21,21 @@ class TaskResolver(TrackedInstance, TaskResolverMixin):
         return "TaskResolver"
 
     def load_task(self, loader_args: List[str]) -> PythonAutoContainerTask:
-        _, app_module, _, unionml_obj, _, task_name, *_ = loader_args
+        # TODO(review,zevisert): I think this is necessary to make the task resolver work with existing
+        # tasks from before the variant was introduced, otherwise we risk breaking existing workflows with
+        # a ValueError(not enough values to unpack). We should remove this once we're confident that all tasks
+        # have been updated to provide the variant arg.
+        if "task-variant" not in loader_args:
+            loader_args.extend(["task-variant", ""])
+
+        _, app_module, _, unionml_obj, _, task_name, _, task_variant, *_ = loader_args
 
         _unionml_obj = getattr(importlib.import_module(app_module), unionml_obj)
         task_method = getattr(_unionml_obj, task_name)
+        if task_name.startswith("callback"):
+            model: Model = _unionml_obj
+            return task_method(model.__callbacks[task_variant])
+
         return task_method()
 
     def loader_args(self, settings: SerializationSettings, task: PythonAutoContainerTask) -> List[str]:
@@ -27,7 +45,9 @@ class TaskResolver(TrackedInstance, TaskResolverMixin):
             "unionml-obj-name",
             task.task_function.__unionml_object__.lhs,
             "task-name",
-            task.task_function.__name__,
+            task.task_function.__name__.split("@")[0],
+            "task-variant",
+            (task.task_config or {}).get("unionml:variant", ""),
         ]
 
 

--- a/unionml/task_resolver.py
+++ b/unionml/task_resolver.py
@@ -1,17 +1,10 @@
 import importlib
-from typing import TYPE_CHECKING, List
+from typing import List
 
 from flytekit.core.base_task import TaskResolverMixin
 from flytekit.core.context_manager import SerializationSettings
 from flytekit.core.python_auto_container import PythonAutoContainerTask
 from flytekit.core.tracker import TrackedInstance
-
-if TYPE_CHECKING:
-    from unionml.model import Model
-else:
-
-    class Model:
-        pass
 
 
 class TaskResolver(TrackedInstance, TaskResolverMixin):
@@ -21,21 +14,10 @@ class TaskResolver(TrackedInstance, TaskResolverMixin):
         return "TaskResolver"
 
     def load_task(self, loader_args: List[str]) -> PythonAutoContainerTask:
-        # TODO(review,zevisert): I think this is necessary to make the task resolver work with existing
-        # tasks from before the variant was introduced, otherwise we risk breaking existing workflows with
-        # a ValueError(not enough values to unpack). We should remove this once we're confident that all tasks
-        # have been updated to provide the variant arg.
-        if "task-variant" not in loader_args:
-            loader_args.extend(["task-variant", ""])
-
-        _, app_module, _, unionml_obj, _, task_name, _, task_variant, *_ = loader_args
+        _, app_module, _, unionml_obj, _, task_name, *_ = loader_args
 
         _unionml_obj = getattr(importlib.import_module(app_module), unionml_obj)
         task_method = getattr(_unionml_obj, task_name)
-        if task_name.startswith("callback"):
-            model: Model = _unionml_obj
-            return task_method(model.callbacks[task_variant])
-
         return task_method()
 
     def loader_args(self, settings: SerializationSettings, task: PythonAutoContainerTask) -> List[str]:
@@ -45,9 +27,7 @@ class TaskResolver(TrackedInstance, TaskResolverMixin):
             "unionml-obj-name",
             task.task_function.__unionml_object__.lhs,
             "task-name",
-            task.task_function.__name__.split("@")[0],
-            "task-variant",
-            (task.task_config or {}).get("unionml:variant", ""),
+            task.task_function.__name__,
         ]
 
 

--- a/unionml/type_guards.py
+++ b/unionml/type_guards.py
@@ -149,7 +149,7 @@ def guard_evaluator(evaluator: Callable, expected_model_type: Type, expected_dat
 
 
 def guard_predictor(predictor: Callable, expected_model_type: Type, expected_data_type: Type):
-    """Ensure that the evaluater has the expected input data and model types."""
+    """Ensure that the predictor has the expected input data and model types."""
     sig = signature(predictor)
     params = [*sig.parameters.values()]
 
@@ -169,8 +169,10 @@ def guard_predictor(predictor: Callable, expected_model_type: Type, expected_dat
         raise TypeError("The 'predictor' function needs a return type annotation.")
 
 
-def guard_callback(callback: Callable, predictor: Callable, expected_model_type: Type, expected_data_type: Type):
-    """Ensure that the evaluater has the expected input data and model types."""
+def guard_prediction_callback(
+    callback: Callable, predictor: Callable, expected_model_type: Type, expected_data_type: Type
+):
+    """Ensure that a callback has the expected model type, along with input and output data types."""
     sig = signature(callback)
     params = [*sig.parameters.values()]
 

--- a/unionml/type_guards.py
+++ b/unionml/type_guards.py
@@ -179,7 +179,7 @@ def guard_callback(callback: Callable, predictor: Callable, expected_model_type:
         raise TypeError("The 'predictor' function needs a return type annotation.")
 
     if sig.return_annotation is not _empty and sig.return_annotation is not None:
-        raise TypeError(f"The 'callback[{callback.__qualname__}]' function must have None as it's return annotation.")
+        raise TypeError(f"The 'callback[{callback.__name__}]' function must have None as it's return annotation.")
 
     actual_model_type = params[0].annotation
     actual_params = [
@@ -188,7 +188,7 @@ def guard_callback(callback: Callable, predictor: Callable, expected_model_type:
 
     if len(actual_params) != 2:
         raise TypeError(
-            f"Callback functions (callback[{callback.__qualname__}]) must take both 'features' and 'prediction' arguments, found {actual_params}"
+            f"Callback functions (callback[{callback.__name__}]) must take both 'features' and 'prediction' arguments, found {actual_params}"
         )
 
     actual_features, actual_prediction = actual_params
@@ -201,7 +201,7 @@ def guard_callback(callback: Callable, predictor: Callable, expected_model_type:
         and actual_model_type not in get_args(expected_model_type)
     ):
         raise TypeError(
-            f"The type of the first argument of the callback[{callback.__qualname__}] function must be compatible with the expected output "
+            f"The type of the first argument of the callback[{callback.__name__}] function must be compatible with the expected output "
             f"type: {expected_model_type}. Found {actual_model_type}"
         )
 
@@ -213,7 +213,7 @@ def guard_callback(callback: Callable, predictor: Callable, expected_model_type:
         and actual_features not in get_args(expected_data_type)
     ):
         raise TypeError(
-            f"The type of the second argument of the callback[{callback.__qualname__}] function must be compatible with the expected output "
+            f"The type of the second argument of the callback[{callback.__name__}] function must be compatible with the expected output "
             f"type: {expected_data_type}. Found {actual_features}"
         )
 
@@ -225,7 +225,7 @@ def guard_callback(callback: Callable, predictor: Callable, expected_model_type:
         and actual_prediction not in get_args(expected_prediction_type)
     ):
         raise TypeError(
-            f"The type of the third argument of the callback[{callback.__qualname__}] function must be compatible with the expected output "
+            f"The type of the third argument of the callback[{callback.__name__}] function must be compatible with the expected output "
             f"type: {expected_prediction_type}. Found {actual_prediction}"
         )
 

--- a/unionml/type_guards.py
+++ b/unionml/type_guards.py
@@ -229,9 +229,6 @@ def guard_callback(callback: Callable, predictor: Callable, expected_model_type:
             f"type: {expected_prediction_type}. Found {actual_prediction}"
         )
 
-    if sig.return_annotation is _empty:
-        raise TypeError("The 'predictor' function needs a return type annotation.")
-
 
 def guard_feature_loader(feature_loader: Callable, expected_data_type: Type):
     """Ensure that the feature loader return type needs to match the parser data input."""

--- a/unionml/type_guards.py
+++ b/unionml/type_guards.py
@@ -169,6 +169,70 @@ def guard_predictor(predictor: Callable, expected_model_type: Type, expected_dat
         raise TypeError("The 'predictor' function needs a return type annotation.")
 
 
+def guard_callback(callback: Callable, predictor: Callable, expected_model_type: Type, expected_data_type: Type):
+    """Ensure that the evaluater has the expected input data and model types."""
+    sig = signature(callback)
+    params = [*sig.parameters.values()]
+
+    expected_prediction_type = signature(predictor).return_annotation
+    if expected_prediction_type is _empty:
+        raise TypeError("The 'predictor' function needs a return type annotation.")
+
+    if sig.return_annotation is not _empty and sig.return_annotation is not None:
+        raise TypeError(f"The 'callback[{callback.__qualname__}]' function must have None as it's return annotation.")
+
+    actual_model_type = params[0].annotation
+    actual_params = [
+        p.annotation for p in params[1:] if p.kind in {Parameter.POSITIONAL_OR_KEYWORD, Parameter.POSITIONAL_ONLY}
+    ]
+
+    if len(actual_params) != 2:
+        raise TypeError(
+            f"Callback functions (callback[{callback.__qualname__}]) must take both 'features' and 'prediction' arguments, found {actual_params}"
+        )
+
+    actual_features, actual_prediction = actual_params
+
+    if (
+        actual_model_type is not Any
+        and expected_model_type is not Any
+        and actual_model_type != expected_model_type
+        and expected_model_type not in get_args(actual_model_type)
+        and actual_model_type not in get_args(expected_model_type)
+    ):
+        raise TypeError(
+            f"The type of the first argument of the callback[{callback.__qualname__}] function must be compatible with the expected output "
+            f"type: {expected_model_type}. Found {actual_model_type}"
+        )
+
+    if (
+        actual_features is not Any
+        and expected_data_type is not Any
+        and actual_features != expected_data_type
+        and expected_data_type not in get_args(actual_features)
+        and actual_features not in get_args(expected_data_type)
+    ):
+        raise TypeError(
+            f"The type of the second argument of the callback[{callback.__qualname__}] function must be compatible with the expected output "
+            f"type: {expected_data_type}. Found {actual_features}"
+        )
+
+    if (
+        actual_prediction is not Any
+        and expected_prediction_type is not Any
+        and actual_prediction != expected_prediction_type
+        and expected_prediction_type not in get_args(actual_prediction)
+        and actual_prediction not in get_args(expected_prediction_type)
+    ):
+        raise TypeError(
+            f"The type of the third argument of the callback[{callback.__qualname__}] function must be compatible with the expected output "
+            f"type: {expected_prediction_type}. Found {actual_prediction}"
+        )
+
+    if sig.return_annotation is _empty:
+        raise TypeError("The 'predictor' function needs a return type annotation.")
+
+
 def guard_feature_loader(feature_loader: Callable, expected_data_type: Type):
     """Ensure that the feature loader return type needs to match the parser data input."""
     sig = signature(feature_loader)

--- a/unionml/utils.py
+++ b/unionml/utils.py
@@ -1,6 +1,6 @@
 import typing
 from functools import partial, wraps
-from inspect import Parameter, signature
+from inspect import Parameter, _empty, signature
 
 from flytekit import task
 
@@ -12,7 +12,7 @@ def inner_task(
     *,
     unionml_obj,
     input_parameters=None,
-    return_annotation=None,
+    return_annotation=_empty,
     **task_kwargs,
 ):
     """A flytekit task defined within a Dataset or Model class.
@@ -48,7 +48,7 @@ def inner_task(
             p.replace(kind=Parameter.KEYWORD_ONLY)
             for p in (fn_sig.parameters if input_parameters is None else input_parameters).values()
         ],
-        return_annotation=fn_sig.return_annotation if return_annotation is None else return_annotation,
+        return_annotation=fn_sig.return_annotation if return_annotation is _empty else return_annotation,
     )
     wrapper.__annotations__.update({k: v.annotation for k, v in input_parameters.items()})
     wrapper.__annotations__["return"] = return_annotation


### PR DESCRIPTION
Closes: #78 
Related: #134 

## Changes proposed (Describe Changes)

<!-- List all the proposed changes in your PR -->
This PR opens the door to custom post-prediction callbacks. Background: Revela is building an API focused ML monitoring system. We already can support UnionML predictions by adding our logging code to the body of a `@model.predictor` decorated function - but from #78, it seems like it would be preferrable to use a different flyte task to handle post-prediction work.

A prediction callback function receives 3 arguments and returns nothing:  
1. The model instance that made the predictions
2. The input data used to invoke the model
3. The model's outputs

Example:
```py

def some_callback(estimator: LogisticRegression, features: pd.DataFrame, predictions: List[float]):
    pass

@model.predictor(callbacks=[some_callback])
def predictor(estimator: LogisticRegression, features: pd.DataFrame) -> List[float]:
   ...
```

With this implementation, all callbacks must match their parameter type annotations to those defined by the `predictor`. `TypeError`s will be raised otherwise.


## Check List (Check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [x] My code follows the code style of this project.
- [x] My change requires changes to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] This PR does not contain plagiarized content.
- [x] The title of my pull request is a short description of the requested changes.

## Screenshots

<details>
<summary>Screenshots from an earlier iteration of this change showing callback functions executing as separate tasks on the flyte console</summary>

For workflows with features:
![image](https://user-images.githubusercontent.com/11222441/196581212-0426d63b-4b91-4280-aad5-e358a6bd302c.png)

For workflows without features:
![image](https://user-images.githubusercontent.com/11222441/196581216-da17b08b-142d-4760-a0c4-371f96a5556e.png)

</details>

## Note to Reviewers

<!-- Add notes to reviewers if applicable -->
- [ ] I need to add integration tests still, just testing the waters on this feature first.
- ~~I **don't** know flyte at all really, so I may be doing things oddly. I initially tried `wf.add_subwf` but couldn't get the input bindings to work correctly -- is a sub workflow a better solution than just conditionally adding tasks?~~
  - For all of my interactions with flyte, assume that I didn't choose the way I did something for any particular reason, call me out on odd usage that you see.
- [x] I left a handful of comments like `# TODO(reveiw,zevisert)` for spots that I had questions that would be best resolved here

## Open in Gitpod

<!-- Gitpod badge will be automatically added here by the bot -->


<a href="https://gitpod.io/#https://github.com/unionai-oss/unionml/pull/195"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

