### PR TITLE
add DCO signoff instructions to contributing, add template

### DIFF
--- a/.github/config.yml
+++ b/.github/config.yml
@@ -1,0 +1,16 @@
+# Comment to be posted on PRs from first-time contributors in your repository
+newPRWelcomeComment: |
+  Thank you for opening this pull request! 🙌
+
+  These tips will help get your PR across the finish line:
+
+  - If you haven't already, check out the [Contributing Guide](https://unionml.readthedocs.io/en/stable/contributing_guide.html)
+  - Sign off your commits (Reference: [DCO Guide](https://github.com/src-d/guide/blob/master/developer-community/fix-DCO.md)).
+
+# Comment to be posted to on pull requests merged by a first time user
+firstPRMergeComment: >
+  Congrats on merging your first pull request! 🎉
+
+# Comment to be posted on first-time issues
+newIssueWelcomeComment: >
+  Thank you for opening your first issue here! 🛠

--- a/docs/source/contributing_guide.md
+++ b/docs/source/contributing_guide.md
@@ -75,6 +75,16 @@ Optionally, you can run integration tests locally. First install [flytectl](http
 python tests/integration
 ```
 
+### DCO-signing Commits
+
+This project enforces the [DCO](https://developercertificate.org/) standard for
+contributions, which requires authors to sign off on their commits. This can be
+done with the `-s` or `--signoff` flag:
+
+```
+git commit -s -m 'my commit'
+```
+
 ### Installing
 
 Install using conda:


### PR DESCRIPTION
Signed-off-by: Niels Bantilan <niels.bantilan@gmail.com>

Adds DCO signoff instructions to contribution guide and PR configuration to the project

<a href="https://gitpod.io/#https://github.com/unionai-oss/unionml/pull/201"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

