### PR TITLE
DOC Remove notes about M1 Mac installation

### DIFF
--- a/docs/source/index.md
+++ b/docs/source/index.md
@@ -115,16 +115,6 @@ your ML models so that you can focus on curating a better dataset and improving 
 pip install unionml
 ```
 
-````{admonition} For M1 Mac users
-:class: important
-
-Before installing `unionml`, follow these StackOverflow posts to install
-[numpy](https://numpy.org/) and [pandas](https://pandas.pydata.org/pandas-docs/stable/):
-
-- [numpy installation](https://stackoverflow.com/a/65581354)
-- [pandas installation](https://stackoverflow.com/a/66048187)
-````
-
 # Quickstart
 
 A UnionML app is composed of two core classes: a {class}`~unionml.dataset.Dataset` and a
@@ -175,12 +165,6 @@ Create a python file called `app.py`, import app dependencies, and define `datas
 
       pip install tensorflow
       ```
-
-      ````{admonition} For M1 Mac users
-      :class: important
-
-      Follow [this StackOverflow post](https://stackoverflow.com/questions/66741778/how-to-install-h5py-needed-for-keras-on-macos-with-m1) to install tensorflow on an M1 Mac
-      ````
 
       ```{literalinclude} ../../tests/integration/keras_app/quickstart.py
       ---


### PR DESCRIPTION
## Changes proposed (Describe Changes)

This PR updates removes the special instructions about installing on M1 Macs. Currently, there are MacOS arm64 wheels for [NumPy](https://pypi.org/project/numpy/1.25.2/#files), [pandas](https://pypi.org/project/pandas/2.1.0/#files) and [tensorflow](https://pypi.org/project/tensorflow/2.13.0/#files), which means these libraries will install correctly through PyPI. I tested `pip install unionml` and `tensorflow` on my M1 Mac and it works out of the box.

<!-- List all the proposed changes in your PR -->

<!-- Mark all the applicable boxes. To mark the box as done follow the following conventions -->
<!--
[x] - Correct; marked as done
[X] - Correct; marked as done

[ ] - Not correct; marked as **not** done
-->

## Check List (Check all the applicable boxes) <!-- Follow the above conventions to check the box -->

- [x] My code follows the code style of this project.
- [x] My change requires changes to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] All new and existing tests passed.
- [x] This PR does not contain plagiarized content.
- [x] The title of my pull request is a short description of the requested changes.

## Open in Gitpod

<!-- Gitpod badge will be automatically added here by the bot -->
