### PR TITLE
FIX Use scikit-learn instead of sklearn in requirements.txt

### DIFF
--- a/unionml/templates/basic-aws-lambda-s3/{{cookiecutter.app_name}}/requirements.txt
+++ b/unionml/templates/basic-aws-lambda-s3/{{cookiecutter.app_name}}/requirements.txt
@@ -1,6 +1,6 @@
 unionml
 boto3
-sklearn
+scikit-learn
 numpy
 pandas
 fastapi

--- a/unionml/templates/basic-aws-lambda/{{cookiecutter.app_name}}/requirements.txt
+++ b/unionml/templates/basic-aws-lambda/{{cookiecutter.app_name}}/requirements.txt
@@ -1,5 +1,5 @@
 unionml
-sklearn
+scikit-learn
 numpy
 pandas
 fastapi

--- a/unionml/templates/basic/{{cookiecutter.app_name}}/requirements.txt
+++ b/unionml/templates/basic/{{cookiecutter.app_name}}/requirements.txt
@@ -2,4 +2,4 @@ unionml
 fastapi
 pandas
 requests
-sklearn
+scikit-learn

--- a/unionml/templates/quickdraw/{{cookiecutter.app_name}}/requirements.txt
+++ b/unionml/templates/quickdraw/{{cookiecutter.app_name}}/requirements.txt
@@ -2,7 +2,7 @@ fastapi
 numpy
 pandas
 requests
-sklearn
+scikit-learn
 torch
 tqdm
 transformers


### PR DESCRIPTION
This PR updates the `requirements.txt` files to use `scikit-learn`. Installing `scikit-learn` with `sklearn` has been deprecated and will be completed removed in Dec 1st 2023.

XREF: https://github.com/scikit-learn/scikit-learn/issues/8215#issuecomment-1308231488